### PR TITLE
Fixes reading GT5 SpecDB which is Big endian

### DIFF
--- a/GTSpecDB.Core/SpecDBTable.cs
+++ b/GTSpecDB.Core/SpecDBTable.cs
@@ -187,6 +187,7 @@ namespace GTSpecDB.Core
             }
             DBT = new DBT_DatabaseTable(buffer, BigEndian ? Endian.Big : Endian.Little);
 
+            sr = new SpanReader(buffer, BigEndian ? Endian.Big : Endian.Little);
             sr.Position = 4;
             versionHigh = sr.ReadUInt16();
             sr.Position += 2;


### PR DESCRIPTION
I'm a bit uncertain on what's going on with this. With the released version 1.1.2 I'm able to read the GT5 SpecDB (2.17 version). But if I build the tool myself from the source, it doesn't work anymore and crashes because the `entryCount` is read as LE instead of BE which it should be. For example GTPSP SpecDB which is LE, the tool works fine without any changes.